### PR TITLE
Update schedule to new weekly times and add date note

### DIFF
--- a/src/app/schedule/page.tsx
+++ b/src/app/schedule/page.tsx
@@ -9,11 +9,23 @@ export const metadata: Metadata = {
 };
 
 export default function SchedulePage() {
+  const weekStartDate = new Date();
+  weekStartDate.setDate(weekStartDate.getDate() - weekStartDate.getDay());
+
+  const formattedWeekStart = weekStartDate.toLocaleDateString("en-US", {
+    month: "long",
+    day: "numeric",
+    year: "numeric",
+  });
+
   return (
     <div className="container mx-auto px-4 py-8">
       <Headline as="h1" size="h1" className="mb-8 md:mb-16 text-center">
         Class Schedule
       </Headline>
+      <p className="mb-8 text-center text-sm text-secondary-foreground/80 md:mb-12">
+        Class times for the week of {formattedWeekStart}
+      </p>
       <Schedule />
     </div>
   );

--- a/src/data/schedule.json
+++ b/src/data/schedule.json
@@ -59,10 +59,10 @@
   ],
   "friday": [
     {
-      "start": "18:00",
-      "end": "until",
-      "class": "Open Mat",
-      "liveStreamed": false
+      "start": "00:00",
+      "end": "23:59",
+      "class": "Closed",
+      "isClosed": true
     }
   ],
   "saturday": [

--- a/src/data/schedule.json
+++ b/src/data/schedule.json
@@ -9,57 +9,39 @@
   ],
   "monday": [
     {
-      "start": "17:30",
-      "end": "18:30",
+      "start": "18:00",
+      "end": "19:00",
       "class": "Adult Jiu Jitsu",
       "liveStreamed": true
     },
     {
-      "start": "18:30",
-      "end": "19:30",
+      "start": "19:00",
+      "end": "20:00",
       "class": "Competition Jiu Jitsu",
-      "liveStreamed": false
-    },
-    {
-      "start": "18:30",
-      "end": "19:30",
-      "class": "Open Rounds",
       "liveStreamed": false
     }
   ],
   "tuesday": [
     {
-      "start": "17:30",
-      "end": "18:30",
-      "class": "Beginner Jiu Jitsu",
-      "liveStreamed": false
-    },
-    {
-      "start": "18:30",
-      "end": "19:30",
+      "start": "18:00",
+      "end": "19:00",
       "class": "Adult Jiu Jitsu",
       "liveStreamed": false
     }
   ],
   "wednesday": [
     {
-      "start": "18:00",
-      "end": "19:00",
-      "class": "Positional Rounds / Grapple Games",
-      "liveStreamed": false
-    },
-    {
-      "start": "19:00",
-      "end": "until",
-      "class": "Open Mat",
-      "liveStreamed": false
+      "start": "00:00",
+      "end": "23:59",
+      "class": "Closed",
+      "isClosed": true
     }
   ],
   "thursday": [
     {
       "start": "17:00",
       "end": "17:45",
-      "class": "Kids Class (Coming Soon!)",
+      "class": "Kids Jiu Jitsu",
       "liveStreamed": false
     },
     {
@@ -72,12 +54,6 @@
       "start": "19:00",
       "end": "20:00",
       "class": "Competition Jiu Jitsu",
-      "liveStreamed": false
-    },
-    {
-      "start": "19:00",
-      "end": "20:00",
-      "class": "Open Rounds",
       "liveStreamed": false
     }
   ],
@@ -91,16 +67,10 @@
   ],
   "saturday": [
     {
-      "start": "10:00",
-      "end": "11:00",
-      "class": "Open Mat",
-      "liveStreamed": false
-    },
-    {
-      "start": "11:00",
-      "end": "12:00",
-      "class": "Competition Jiu Jitsu",
-      "liveStreamed": false
+      "start": "00:00",
+      "end": "23:59",
+      "class": "Closed",
+      "isClosed": true
     }
   ],
   "overrides": [


### PR DESCRIPTION
## Summary
- update the schedule data for Monday, Tuesday, Wednesday, Thursday, and Saturday per the new class times and closures
- add a contextual note under the Class Schedule heading showing the week start date

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691f50b1cd88832cb2669f1f63b50cfa)