### PR TITLE
Enable system default theme

### DIFF
--- a/src/components/theme/theme-provider.tsx
+++ b/src/components/theme/theme-provider.tsx
@@ -83,8 +83,8 @@ export function ThemeProvider({
     <ThemeContext.Provider value={{ theme, setTheme: handleThemeChange }}>
       <NextThemeProvider
         attribute="class"
-        defaultTheme="dark"
-        enableSystem={false}
+        defaultTheme="system"
+        enableSystem={true}
       >
         {children}
       </NextThemeProvider>


### PR DESCRIPTION
## Summary
- configure the Next.js theme provider to use the system theme by default
- keep stored theme preferences overriding the system setting on return visits

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691f53fbeda4832cb31a48ab6e6767c4)