### PR TITLE
Update homepage hero headline and subhead

### DIFF
--- a/src/components/hero/hero.tsx
+++ b/src/components/hero/hero.tsx
@@ -39,16 +39,17 @@ export function Hero() {
         <LivestreamCallout />
         {isEnhanced ? (
           <Headline className="max-w-4xl">
-            Good things come to those who Grapple.
+            The Science of Submission Grappling in Flowood.
           </Headline>
         ) : (
           <h1 className="max-w-4xl text-4xl font-extrabold tracking-tight sm:text-5xl md:text-6xl lg:text-7xl bg-clip-text text-transparent bg-gradient-to-b from-foreground to-muted-foreground/80">
-            Good things come to those who Grapple.
+            The Science of Submission Grappling in Flowood.
           </h1>
         )}
         <p className="mt-8 max-w-2xl text-xl md:text-2xl text-gray-700 dark:text-white/90">
-          We&apos;re obsessed with learning and growing the beautiful art of
-          submission grappling.
+          We teach a systematic, No-Gi approach to Jiu Jitsu that builds real
+          confidence and technical skill. No ego, no fluff—just a community
+          obsessed with learning and growing.
         </p>
 
         <div className="mt-12 flex gap-6 justify-center">

--- a/src/components/hero/hero.tsx
+++ b/src/components/hero/hero.tsx
@@ -39,17 +39,16 @@ export function Hero() {
         <LivestreamCallout />
         {isEnhanced ? (
           <Headline className="max-w-4xl">
-            The Science of Submission Grappling in Flowood.
+            Flowood&apos;s Dedicated No-Gi Jiu Jitsu Academy.
           </Headline>
         ) : (
           <h1 className="max-w-4xl text-4xl font-extrabold tracking-tight sm:text-5xl md:text-6xl lg:text-7xl bg-clip-text text-transparent bg-gradient-to-b from-foreground to-muted-foreground/80">
-            The Science of Submission Grappling in Flowood.
+            Flowood&apos;s Dedicated No-Gi Jiu Jitsu Academy.
           </h1>
         )}
         <p className="mt-8 max-w-2xl text-xl md:text-2xl text-gray-700 dark:text-white/90">
-          We teach a systematic, No-Gi approach to Jiu Jitsu that builds real
-          confidence and technical skill. No ego, no fluff—just a community
-          obsessed with learning and growing.
+          A modern, safe, and systematic approach to submission grappling.
+          Perfect for beginners, competitors, and everyone in between.
         </p>
 
         <div className="mt-12 flex gap-6 justify-center">


### PR DESCRIPTION
### Motivation
- Update the homepage hero to reflect the new marketing copy emphasizing a systematic No-Gi approach and the Flowood location. 
- Make the headline more specific and the subhead more descriptive about the gym's teaching philosophy. 

### Description
- Replaced the hero headline text in `src/components/hero/hero.tsx` for both the enhanced `Headline` and fallback `h1` with the new headline. 
- Updated the hero paragraph (subhead) copy in the same file to the provided No-Gi, no-ego messaging. 
- Preserved existing layout, buttons, and background behavior; this is a copy-only change. 

### Testing
- Started the dev server with `npm run dev` and the app compiled and served pages successfully. 
- Verified the app responded to `GET /` with a `200` during the dev run. 
- Attempted an automated screenshot using Playwright, but Chromium crashed in this environment so no screenshot was captured. 
- No automated test suite is configured or run for this change (copy-only update).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6954c82fcc8c832c9e09a8c4fc86a371)