### PR TITLE
Mark Wed 6am & Fri 12pm classes as 'Requires RSVP' and add schedule note

### DIFF
--- a/src/app/schedule/page.tsx
+++ b/src/app/schedule/page.tsx
@@ -26,6 +26,10 @@ export default function SchedulePage() {
       <p className="mb-8 text-center text-sm text-secondary-foreground/80 md:mb-12">
         Class times for the week of {formattedWeekStart}
       </p>
+      <p className="mb-10 text-center text-sm text-secondary-foreground/80">
+        Classes marked “Requires RSVP” can be booked by members through their
+        account, and visitors/non-members can call ahead to reserve a spot.
+      </p>
       <Schedule />
     </div>
   );

--- a/src/data/schedule.json
+++ b/src/data/schedule.json
@@ -50,7 +50,7 @@
     {
       "start": "06:00",
       "end": "07:00",
-      "class": "Jiu Jitsu Fundamentals"
+      "class": "Jiu Jitsu Fundamentals (Requires RSVP)"
     },
     {
       "start": "18:00",
@@ -89,7 +89,7 @@
     {
       "start": "12:00",
       "end": "13:00",
-      "class": "Adult Jiu Jitsu"
+      "class": "Adult Jiu Jitsu (Requires RSVP)"
     },
     {
       "start": "18:00",


### PR DESCRIPTION
### Motivation
- Indicate that the Wednesday 6:00am and Friday 12:00pm classes require RSVP so members know to book through their account and visitors know to call ahead.

### Description
- Append "(Requires RSVP)" to the Wednesday 6:00am and Friday 12:00pm class names in `src/data/schedule.json` and add an explanatory note on the schedule page at `src/app/schedule/page.tsx`.

### Testing
- Ran the dev server with `npm run dev` which compiled the `/schedule` page (with Google font warnings) and executed a Playwright script to capture `/schedule` to `artifacts/schedule-rsvp.png`, both actions completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696e779c1454832cab8868852c5ffc27)